### PR TITLE
update healing projects for units gene modded while wounded.

### DIFF
--- a/Gene Modding Facility/Src/WotC_Gameplay_GeneModding/Classes/XComGameStateContext_HeadquartersOrder_GeneMod.uc
+++ b/Gene Modding Facility/Src/WotC_Gameplay_GeneModding/Classes/XComGameStateContext_HeadquartersOrder_GeneMod.uc
@@ -295,7 +295,15 @@ static function CancelSoldierTrainingProject(XComGameState AddToGameState, State
 				UnitState.SetUnitFloatValue('GeneModsImplantsFailed', UV_Holder, eCleanup_Never);
 			}
 
-			UnitState.SetStatus(eStatus_Active);
+			if(!UnitState.IsInjured())
+			{
+				UnitState.SetStatus(eStatus_Active);
+			}
+			else
+			{
+				// Set the unit back to healing status if they are injured.
+				UnitState.SetStatus(eStatus_Healing);
+			}
 
 			// Remove the soldier from the staff slot
 			StaffSlotState = UnitState.GetStaffSlot();


### PR DESCRIPTION
Fixes Issue #25.

This change adjusts the code that runs when the gene mod completes. It completes a unit's healing project if found and the unit has been set to full HP, or updates the status of the healing project and marks the unit as healing if the unit wasn't healed to full HP by the gene mod.

I've done some preliminary testing with LWoTC, checking the healing projects via console command, and gene modding both wounded and healthy units.  Needs confirmation this code works with Augmentations.